### PR TITLE
feat: disable trim quotes

### DIFF
--- a/src/__tests__/extract-primitives.test.ts
+++ b/src/__tests__/extract-primitives.test.ts
@@ -9,14 +9,14 @@ const Minato = {
   isInOsaka: false,
   area: 20.37,
   Roppongi: {
-    Station: 'H04',
+    Station: "'H04'",
   },
 };
 const Chiyoda = {
   isInOsaka: false,
   area: 11.66,
   Ochanomizu: {
-    Station: 'C12',
+    Station: "'C12'",
   },
 };
 
@@ -29,11 +29,22 @@ describe('trimQuotes', () => {
 });
 
 describe('extractPrimitives', () => {
-  it('works correctly', () => {
+  it('works correctly without options', () => {
     const result = extractPrimitives([sample]);
     const expected = {
       Japan: {
         Tokyo: { Minato },
+      },
+    };
+
+    expect(result).toEqual(expected);
+  });
+
+  it('works correctly if trimQuates = true', () => {
+    const result = extractPrimitives([sample], { trimQuates: true });
+    const expected = {
+      Japan: {
+        Tokyo: { Minato: { ...Minato, Roppongi: { Station: 'H04' } } },
       },
     };
 

--- a/src/extract-primitives.ts
+++ b/src/extract-primitives.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import fs from 'fs';
 
 type Nest = Record<string, any>;
 const nest = (): Nest => Object.create(null);
@@ -9,11 +10,14 @@ interface Options {
 
 // a function which extract values to be replaced with DefinePlugin from `.d.ts` files
 export const extractPrimitives = (files: string[], options: Options = {}): Nest => {
-  const program = ts.createProgram({ rootNames: files, options: {} });
-  program.getTypeChecker(); // init type checker
-
   const result = files.reduce<Nest>((acc, file) => {
-    const source = program.getSourceFile(file);
+    const source = ts.createSourceFile(
+      file,
+      fs.readFileSync(file, { encoding: 'utf-8' }),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    );
     return source ? extractFromSingleSource(acc, source, options) : acc;
   }, nest());
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
 import { extractPrimitives } from './extract-primitives';
-module.exports = Object.assign(extractPrimitives, exports);
 export default extractPrimitives;
 export * from './extract-primitives';


### PR DESCRIPTION
- disable using `trimQuates` by default in order to wrap string values with quotes for the sake of webpack DefinePlugin.
- fix how to export values in `src/index.ts`
- use `ts.createSourceFile` instead of the way via `ts.createProgram` for the sake of performance